### PR TITLE
Performance optimizations

### DIFF
--- a/lib/node-xml.js
+++ b/lib/node-xml.js
@@ -612,16 +612,6 @@ XMLP.prototype._parseText = function(iB) {
         }
     }
     
-    // iE = this.m_xml.indexOf("<", iB);
-    // if(iE == -1) {
-    //     iE = this.m_xml.length;
-    // }
-    // 
-    // iEE = this.m_xml.indexOf("&", iB);
-    // if((iEE != -1) && (iEE <= iE)) {
-    //     iE = iEE;
-    // }
-
     this._setContent(XMLP._CONT_XML, iB, iE);
 
     this.m_iP = iE;

--- a/lib/node-xml.js
+++ b/lib/node-xml.js
@@ -234,7 +234,11 @@ XMLP.prototype._parse = function() {
         return XMLP._NONE;
     }
 
-    if(this.m_iP == this.m_xml.indexOf("<?",        this.m_iP)) {
+    var fc = this.m_xml.charAt(this.m_iP);
+    if (fc !== '<' && fc !== '&') {
+        return this._parseText   (this.m_iP);        
+    }    
+    else if(this.m_iP == this.m_xml.indexOf("<?",        this.m_iP)) {
         return this._parsePI     (this.m_iP + 2);
     }
     else if(this.m_iP == this.m_xml.indexOf("<!DOCTYPE", this.m_iP)) {
@@ -599,17 +603,24 @@ XMLP.prototype._parsePI = function(iB) {
 }
 
 XMLP.prototype._parseText = function(iB) {
-    var iE, iEE;
+    var iE, ch;
 
-    iE = this.m_xml.indexOf("<", iB);
-    if(iE == -1) {
-        iE = this.m_xml.length;
+    for (iE=iB; iE<this.m_xml.length; ++iE) {
+        ch = this.m_xml.charAt(iE);
+        if (ch === '<' || ch === '&') {
+            break;
+        }
     }
-
-    iEE = this.m_xml.indexOf("&", iB);
-    if((iEE != -1) && (iEE <= iE)) {
-        iE = iEE;
-    }
+    
+    // iE = this.m_xml.indexOf("<", iB);
+    // if(iE == -1) {
+    //     iE = this.m_xml.length;
+    // }
+    // 
+    // iEE = this.m_xml.indexOf("&", iB);
+    // if((iEE != -1) && (iEE <= iE)) {
+    //     iE = iEE;
+    // }
 
     this._setContent(XMLP._CONT_XML, iB, iE);
 


### PR DESCRIPTION
By using fast checks on the first character in XMLP.prototype._parse as well as concurrently scanning for multiple chars in XMLP.prototype._parseText, parsing 1MB XML files with mostly elements + text is now down from 4+m to 1m30s.
