### PR TITLE
Allow detection of empty elements - Issue #22

### DIFF
--- a/lib/node-xml.js
+++ b/lib/node-xml.js
@@ -958,6 +958,9 @@ SaxParser.prototype._fireEvent = function(iEvt) {
         else if (5 == iLen) {
             hnd[func](args[1], args[2], args[3], args[4], args[5]);
         }
+        else if (6 == iLen) {
+            hnd[func](args[1], args[2], args[3], args[4], args[5], args[6]);
+        }
     }
 
 }
@@ -991,10 +994,10 @@ SaxParser.prototype._parseLoop = function(parser) {
             nameobject = parser._parsePrefixAndElementName(parser.getName());
             theattsandnamespace = parser._parseNamespacesAndAtts(theatts);
             var theuri = parser._getContextualNamespace(nameobject.prefix);
-            this._fireEvent(SaxParser.ELM_B, nameobject.name, theattsandnamespace[0], (nameobject.prefix === '')? null : nameobject.prefix, (theuri === '')? null : theuri ,theattsandnamespace[1] );
+            this._fireEvent(SaxParser.ELM_B, nameobject.name, theattsandnamespace[0], (nameobject.prefix === '')? null : nameobject.prefix, (theuri === '')? null : theuri ,theattsandnamespace[1], true );
 
             parser._removeExpiredNamesapces(parser.getName());
-            this._fireEvent(SaxParser.ELM_E, nameobject.name, (nameobject.prefix === '')? null : nameobject.prefix, (theuri === '')? null : theuri);
+            this._fireEvent(SaxParser.ELM_E, nameobject.name, (nameobject.prefix === '')? null : nameobject.prefix, (theuri === '')? null : theuri, true);
             //this._fireEvent(SaxParser.ELM_B, parser.getName(), this.m_parser.m_atts.map(function(item){return { name : item[0], value : item[1], };}) );
             //this._fireEvent(SaxParser.ELM_E, parser.getName());
         }


### PR DESCRIPTION
I have added an additional parameter to callbacks `onBeginElementNS` and `onEndElementNS` so that empty elements can be detected when parsing.

For example:

``` xml
<list>
    <item><item>
    <item />
</list>
```

The first `item` is called as follows:

``` javascript
onBeginElementNS('item', {}, null, null, [])
onEndElementNS('item', null, null)
```

The second `item` is called as follows:

``` javascript
onBeginElementNS('item', {}, null, null, [], true)
onEndElementNS('item', null, null, true)
```
