### PR TITLE
Fixed issue 26, "XML entities in attributes are not escaped"

### DIFF
--- a/lib/node-xml.js
+++ b/lib/node-xml.js
@@ -631,7 +631,7 @@ XMLP.prototype._replaceEntities = function(strD, iB, iE) {
     iEB = strD.indexOf("&", iB);
     iEE = iB;
 
-    while((iEB > 0) && (iEB < iE)) {
+    while((iEB > -1) && (iEB < iE)) {
         strRet += strD.substring(iEE, iEB);
 
         iEE = strD.indexOf(";", iEB) + 1;


### PR DESCRIPTION
Fixed issue 26, "XML entities in attributes are not escaped": https://github.com/robrighter/node-xml/issues/26
