### PR TITLE
endDocument is called even after pause/resume used

### DIFF
--- a/lib/node-xml.js
+++ b/lib/node-xml.js
@@ -234,33 +234,41 @@ XMLP.prototype._parse = function() {
         return XMLP._NONE;
     }
 
+    function _indexOf(needle, haystack, start) {
+        // This is an improvement over the native indexOf because it stops at the
+        // end of the needle and doesn't continue to the end of the haystack looking.
+        for(var i = 0; i < needle.length; i++) {
+            if(needle.charAt(i) != haystack.charAt(start + i))
+                return -1;
+        }
+        return start;
+    }
+
     var fc = this.m_xml.charAt(this.m_iP);
     if (fc !== '<' && fc !== '&') {
-        return this._parseText   (this.m_iP);        
-    }    
-    else if(this.m_iP == this.m_xml.indexOf("<?",        this.m_iP)) {
+        return this._parseText   (this.m_iP);
+    }
+    else if(this.m_iP == _indexOf("<?", this.m_xml, this.m_iP)) {
         return this._parsePI     (this.m_iP + 2);
     }
-    else if(this.m_iP == this.m_xml.indexOf("<!DOCTYPE", this.m_iP)) {
+    else if(this.m_iP == _indexOf("<!DOCTYPE", this.m_xml, this.m_iP)) {
         return this._parseDTD    (this.m_iP + 9);
     }
-    else if(this.m_iP == this.m_xml.indexOf("<!--",      this.m_iP)) {
+    else if(this.m_iP == _indexOf("<!--", this.m_xml, this.m_iP)) {
         return this._parseComment(this.m_iP + 4);
     }
-    else if(this.m_iP == this.m_xml.indexOf("<![CDATA[", this.m_iP)) {
+    else if(this.m_iP == _indexOf("<![CDATA[", this.m_xml, this.m_iP)) {
         return this._parseCDATA  (this.m_iP + 9);
     }
-    else if(this.m_iP == this.m_xml.indexOf("<",         this.m_iP)) {
+    else if(this.m_iP == _indexOf("<", this.m_xml, this.m_iP)) {
         return this._parseElement(this.m_iP + 1);
     }
-    else if(this.m_iP == this.m_xml.indexOf("&",         this.m_iP)) {
+    else if(this.m_iP == _indexOf("&", this.m_xml, this.m_iP)) {
         return this._parseEntity (this.m_iP + 1);
     }
     else{
         return this._parseText   (this.m_iP);
     }
-
-
 }
 
 ////////// NAMESPACE SUPPORT //////////////////////////////////////////

--- a/lib/node-xml.js
+++ b/lib/node-xml.js
@@ -839,10 +839,15 @@ SaxParser.prototype.pause = function() {
 SaxParser.prototype.resume = function() {
     //reset the state
     this.m_parser.resume();
+    this.m_interrupted = false;
+    
     //now start up the parse loop
     var that = this;
     setTimeout(function(){
             that._parseLoop();
+            if(!that.m_bErr && !that.m_interrupted) {
+                that._fireEvent(SaxParser.DOC_E);
+            }
     }, 0);
 }
 


### PR DESCRIPTION
With the current code after an interrupt is sent, i.e. a pause() is called the interrupt flag is never reset to false at any point so endDocument can never be called. I'm sure this could be improved further but it works for the scenario I need it to work so enjoy :)
