### PR TITLE
Mocha reports variable leaks into global scope

### DIFF
--- a/lib/node-xml.js
+++ b/lib/node-xml.js
@@ -480,7 +480,7 @@ XMLP.prototype._parseDTD = function(iB) {
 }
 
 XMLP.prototype._parseElement = function(iB) {
-    util = require('util');
+    var util = require('util');
     var iE, iDE, iNE, iRet;
     var iType, strN, iLast;
 
@@ -805,7 +805,7 @@ SaxParser.prototype.parseFile = function(filename) { //This function will only w
 
 
 SaxParser.prototype.parseString = function(strD) {
-    util = require('util');
+    var util = require('util');
     var that = this;
     var startnew = true;
     if(!that.m_parser){

--- a/lib/node-xml.js
+++ b/lib/node-xml.js
@@ -273,14 +273,14 @@ XMLP.prototype._parse = function() {
 
 ////////// NAMESPACE SUPPORT //////////////////////////////////////////
 XMLP.prototype._parsePrefixAndElementName = function (elementlabel){
-    splits = elementlabel.split(':',2);
+    var splits = elementlabel.split(':',2);
     return { prefix : ((splits.length === 1) ? '' : splits[0]), name : ((splits.length === 1) ? elementlabel : splits[1]), };
 }
 
 XMLP.prototype._parseNamespacesAndAtts = function (atts){
    //translate namespaces into objects with "prefix","uri", "scopetag" Add them to: this.m_namespaceList
    //The function should return a new list of tag attributes with the namespaces filtered
-    that = this;
+    var that = this;
     var newnamespaces = [];
     var filteredatts = [];
     atts.map(function (item){
@@ -339,7 +339,7 @@ XMLP.prototype._removeExpiredNamesapces = function (closingtagname) {
 
 
 XMLP.prototype._parseAttribute = function(iB, iE) {
-    var iNB, iNE, iEq, iVB, iVE;
+    var iNB, iNE, iEq, iVB, iVE, iRet;
     var cQuote, strN, strV;
 
 	this.m_cAlt = ""; //resets the value so we don't use an old one by accident (see testAttribute7 in the test suite)
@@ -634,7 +634,7 @@ XMLP.prototype._replaceEntities = function(strD, iB, iE) {
     iE = iE || strD.length;
 
 
-    var iEB, iEE, strRet = "";
+    var iEB, iEE, strRet = "", iRet;
 
     iEB = strD.indexOf("&", iB);
     iEE = iB;
@@ -978,7 +978,7 @@ SaxParser.prototype._fireEvent = function(iEvt) {
 
 
 SaxParser.prototype._parseLoop = function(parser) {
-    var iEvent, parser;
+    var iEvent, parser, theattsandnamespace, theatts, nameobject;
 
     parser = this.m_parser;
     while(!this.m_bErr) {


### PR DESCRIPTION
Mocha (http://visionmedia.github.com/mocha/) reports some errors in a projet of mine that uses SaxParser().
For instance:
  Error: global leak detected: util
  Error: global leaks detected: iRet, theatts, splits, nameobject, that
