### PR TITLE
Removed confusing use of new Array()

### DIFF
--- a/lib/node-xml.js
+++ b/lib/node-xml.js
@@ -63,7 +63,7 @@ XMLP._STATE_PROLOG = 1;
 XMLP._STATE_DOCUMENT = 2;
 XMLP._STATE_MISC = 3;
 
-XMLP._errs = new Array();
+XMLP._errs = [];
 XMLP._errs[XMLP.ERR_CLOSE_PI       = 0 ] = "PI: missing closing sequence";
 XMLP._errs[XMLP.ERR_CLOSE_DTD      = 1 ] = "DTD: missing closing sequence";
 XMLP._errs[XMLP.ERR_CLOSE_COMMENT  = 2 ] = "Comment: missing closing sequence";
@@ -106,7 +106,7 @@ XMLP.prototype.continueParsing = function(strXML) {
 }
 
 XMLP.prototype._addAttribute = function(name, value) {
-    this.m_atts[this.m_atts.length] = new Array(name, value);
+    this.m_atts[this.m_atts.length] = [name, value];
 }
 
 XMLP.prototype._checkStructure = function(iEvent) {


### PR DESCRIPTION
I argue that `[]` should be used instead of `new Array()`, and especially instead of `new Array(arg0, arg1, ...)` to avoid confusion (i.e. I was confused when I saw it).

I wasn't sure if there would be a bug or not in the case that `name` was a number and `value` was undefined. According to Firefox, it should never result in a bug. I assume Chrome behaves the same way.

https://developer.mozilla.org/en-US/docs/JavaScript/Reference/Global_Objects/Array
