### PR TITLE
replace left, right quote for string

### DIFF
--- a/lib/node-xml.js
+++ b/lib/node-xml.js
@@ -1245,12 +1245,14 @@ function __unescapeString(str) {
     var escGtRegEx = /&gt;/g;
     var quotRegEx = /&quot;/g;
     var aposRegEx = /&apos;/g;
+    var lrdquoRegEx = /&[lr]dquo;/g;
 
     str = str.replace(escAmpRegEx, "&");
     str = str.replace(escLtRegEx, "<");
     str = str.replace(escGtRegEx, ">");
     str = str.replace(quotRegEx, "\"");
     str = str.replace(aposRegEx, "'");
+    str = str.replace(lrdquoRegEx, "\"");
 
   return str;
 }


### PR DESCRIPTION
- Some xml file contains left and right quote and quote character in CDATA tag
  for ex: “a text inside left and right quote”
- Left and right quote in CDATA tag was escaped by: &ldquo; and &rdquo;
- Therefore, I add lrdRegEx to replace left and right quote to quote
